### PR TITLE
Reserve mission functionality

### DIFF
--- a/src/components/Mission-components/MissionData.js
+++ b/src/components/Mission-components/MissionData.js
@@ -1,26 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { handleReservation } from '../../redux/missions/missions';
 
-const MissionData = ({ name, description, reserved }) => (
-  <tr className="row">
-    <td className="column mission-name">{name}</td>
-    <td className="column mission-desc">{description}</td>
-    <td className="column mission-status">
-      {!reserved && (<p className="not-reserved">Not A Member</p>)}
-      {reserved && (<p className="reserved">Active Member</p>)}
-    </td>
-    <td className="column mission-button">
-      {!reserved && (
-      <button type="button" className="btn">Join Mission</button>
-      )}
-      {reserved && (
-      <button type="button" className="btn-leave">Leave Mission</button>
-      )}
-    </td>
-  </tr>
-);
+const MissionData = ({
+  id, name, description, reserved,
+}) => {
+  const dispatch = useDispatch();
+
+  const handleMissionReservation = ({ target }) => {
+    const { type } = target.dataset;
+    dispatch(handleReservation({ id, type }));
+  };
+
+  return (
+    <tr className="row">
+      <td className="column mission-name">{name}</td>
+      <td className="column mission-desc">{description}</td>
+      <td className="column mission-status">
+        {!reserved && (<p className="not-reserved">Not A Member</p>)}
+        {reserved && (<p className="reserved">Active Member</p>)}
+      </td>
+      <td className="column mission-button">
+        {!reserved && (
+          <button type="button" className="btn" data-type="join" onClick={handleMissionReservation}>Join Mission</button>
+        )}
+        {reserved && (
+          <button type="button" className="btn-leave" data-type="leave" onClick={handleMissionReservation}>Leave Mission</button>
+        )}
+      </td>
+    </tr>
+  );
+};
 
 MissionData.propTypes = {
+  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   reserved: PropTypes.bool.isRequired,

--- a/src/components/Mission-components/MissionsTable.js
+++ b/src/components/Mission-components/MissionsTable.js
@@ -18,6 +18,7 @@ const MissionTable = () => {
         {missionList.map((mission) => (
           <MissionData
             key={mission.mission_id}
+            id={mission.mission_id}
             name={mission.mission_name}
             description={mission.description}
             reserved={mission.reserved}

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, current } from '@reduxjs/toolkit';
 
 const FETCH_MISSION_API = 'https://api.spacexdata.com/v3/missions';
 const INITIAL_STATE = { missionList: [], loading: true };
@@ -12,7 +12,21 @@ export const fetchMissions = createAsyncThunk('spacex/missions/FETCH_MISSIONS', 
 const missionSlice = createSlice({
   name: 'missions',
   initialState: INITIAL_STATE,
-  reducers: {},
+  reducers: {
+    handleReservation: (state, action) => {
+      const { id, type } = action.payload;
+      const newMissions = current(state).missionList.map((mission) => {
+        if(type === 'join' && id === mission.mission_id) {
+          return { ...mission, reserved: true };
+        }
+        if(type === 'leave' && id === mission.mission_id) {
+          return { ...mission, reserved: false };
+        }
+        return mission;
+      });
+      state.missionList = newMissions;
+    }
+  },
   extraReducers: {
     [fetchMissions.fulfilled]: (state, action) => {
       const res = action.payload.map(({mission_id, mission_name, description}) => {
@@ -25,5 +39,7 @@ const missionSlice = createSlice({
     [fetchMissions.rejected]: (state) => { state.loading = false },
   }
 });
+
+export const { handleReservation }  = missionSlice.actions;
 
 export default missionSlice.reducer;


### PR DESCRIPTION
### Implement Mission Joining and Leaving
- Implemented mission joining and leaving functionality.
- Used `map` to return the new state with `reserved: true` and `reserved: false` respectively.
- Both of these functionality logics are placed in `reducers`.
- From the view, only `action` with the correct mission `id` and type of action, i.e `join` or `leave` is `dispatched` using `hooks`.
- Showing `reserved` badge and the `buttons` using `javascript` conditional rendering.