### PR TITLE
Show reserved rockets in My Profile

### DIFF
--- a/src/components/Myprofile.js
+++ b/src/components/Myprofile.js
@@ -1,7 +1,21 @@
+import '../css/Missions.css';
 import '../css/Profile.css';
+import { useSelector } from 'react-redux';
+import ProfileTable from './Profile-components/ProfileTables';
 
-const MyProfile = () => (
-  <></>
-);
+const MyProfile = () => {
+  const { Rockets } = useSelector((state) => state.rockets);
+
+  const reservedRockets = Rockets.filter(({ reserved }) => reserved === true);
+
+  return (
+    <section className="mission-container">
+      <div className="profile-holder">
+        <ProfileTable dataList={reservedRockets} header="My Rockets" type="rockets" />
+        <ProfileTable dataList={reservedRockets} header="My Missions" type="rockets" />
+      </div>
+    </section>
+  );
+};
 
 export default MyProfile;

--- a/src/components/Profile-components/ProfileTables.js
+++ b/src/components/Profile-components/ProfileTables.js
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import RandomId from '../../helpers/Random';
+
+const ProfileTable = ({ header, dataList, type }) => (
+  <div className="Flex">
+    <h2 className="profile-heading table-heading">{header}</h2>
+    <table className="profile-table">
+      <tbody>
+        {dataList.map((data) => (
+          <tr key={RandomId()}>
+            <td className="column data-name">
+              {type === 'rockets' ? data.name : data.mission_name}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+ProfileTable.propTypes = {
+  header: PropTypes.string.isRequired,
+  dataList: PropTypes.node.isRequired,
+  type: PropTypes.string.isRequired,
+};
+
+export default ProfileTable;

--- a/src/css/Profile.css
+++ b/src/css/Profile.css
@@ -1,3 +1,22 @@
-* {
-  margin: 0;
+.profile-holder {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin-top: 120px;
+}
+
+.profile-table {
+  border-collapse: collapse;
+  margin: 0 auto;
+  table-layout: auto;
+  width: 90%;
+}
+
+.Flex {
+  flex: 1 1 40%;
+}
+
+.profile-heading {
+  margin: 0 auto;
+  width: 90%;
 }

--- a/src/helpers/Random.js
+++ b/src/helpers/Random.js
@@ -1,0 +1,3 @@
+const RandomId = () => Date.now() + Math.floor(Math.random() * 9999999);
+
+export default RandomId;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,13 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import rockets from './rockets/rockets';
 import missions from './missions/missions';
-import profile from './profile/profile';
 
 const store = configureStore({
   reducer: {
     rockets,
     missions,
-    profile,
   },
 });
 

--- a/src/redux/profile/profile.js
+++ b/src/redux/profile/profile.js
@@ -1,4 +1,0 @@
-const profile = () => (
-  <></>
-);
-export default profile;


### PR DESCRIPTION
## Showing Reserved Rockets From `Redux Store`
- Used `filter()` to filter out the **reserved** rockets.
- Showing the **reserved** rockets in a table format on **My Profile** page.
- Followed `DRY`, `KISS`, and `YAGNI`.